### PR TITLE
keep const ref in storage::configuration_provider.

### DIFF
--- a/include/yugawara/storage/basic_configurable_provider.h
+++ b/include/yugawara/storage/basic_configurable_provider.h
@@ -314,11 +314,11 @@ private:
             const_value_ { value_ }
         {}
 
-        std::shared_ptr<T> const& ref() const {
+        [[nodiscard]] std::shared_ptr<T> const& ref() const {
             return value_;
         }
         
-        std::shared_ptr<T const> const& const_ref() const {
+        [[nodiscard]] std::shared_ptr<T const> const& const_ref() const {
             return const_value_;
         }
         


### PR DESCRIPTION
This revision is only for optimization.
It will reduce copy of shared_ptr on calling each.