### PR TITLE
add missing includes (for FTBFS with gcc-11)

### DIFF
--- a/include/yugawara/storage/sequence.h
+++ b/include/yugawara/storage/sequence.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <numeric>
 #include <optional>
 #include <ostream>

--- a/include/yugawara/util/maybe_shared_lock.h
+++ b/include/yugawara/util/maybe_shared_lock.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include <shared_mutex>
 
 #include <takatori/util/meta_type.h>


### PR DESCRIPTION
g++-11 で使用する libstdc++ でヘッダファイルの依存関係が変更となり、
`#include` を省略していたもののコンパイルが通らなくなることがあります。

参考:
https://gcc.gnu.org/gcc-11/porting_to.html#header-dep-changes

これへの対応となります。