### PR TITLE
fix: remove invalid assertion for flow with empty columns.

### DIFF
--- a/src/yugawara/analyzer/details/rewrite_stream_variables.cpp
+++ b/src/yugawara/analyzer/details/rewrite_stream_variables.cpp
@@ -363,7 +363,6 @@ private:
 
     template<class Columns>
     void define_used_columns(exchange_column_info& info, Columns& columns) {
-        BOOST_ASSERT(!columns.empty()); // NOLINT
         for (auto&& it = columns.begin(); it != columns.end();) {
             auto&& column = *it;
             if (context_.try_rewrite_define(column.destination())) {


### PR DESCRIPTION
This PR suppresses assertion failure when some dataflow columns are empty while building a step graph.

For example, the following SQL:

```sql
SELECT t1.k FROM t1, t2;
```

This becomes crash the database service with following logs:

```txt
Assertion '!columns.empty()' was failed in 'void yugawara::analyzer::details::{anonymous}::engine::define_used_columns(yugawara::analyzer::details::exchange_column_info&, Columns&) [with Columns = std::vector<takatori::relation::details::mapping_element>]'
 0# boost::assertion_failed(char const*, char const*, char const*, long) at /tmp/tsurugidb/takatori/src/takatori/util/assertion.cpp:25
 1# yugawara::analyzer::details::(anonymous namespace)::engine::operator()(takatori::plan::process&)::{lambda(takatori::relation::expression&)#1}::operator()(takatori::relation::expression&) const at /tmp/tsurugidb/yugawara/src/yugawara/analyzer/details/rewrite_stream_variables.cpp:77
... (snip)
```

This will produce the following step graph in the current version of tsurugi:

```txt
{ scan[t1] -- offer } -- { group } --\
                                      +-- { take_cogroup -- join_group -- emit[t1.k] }
{ scan[t2] -- offer } -- { group } --/
```

Here, the columns in the data flow starting from `scan[t2]` will become an empty flow due to optimization because no one will use these columns in the entire execution plan.
Since the code may raise the above assertion failures for such the empty flows, removed in this PR.