### PR TITLE
remove transitive dependency from takatori

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.65
     COMPONENTS container
-    COMPONENTS stacktrace_backtrace
     REQUIRED)
 
 find_package(Doxygen


### PR DESCRIPTION
takatori は Boost::stacktrace_backtrace への依存していましたが、推移的依存関係の設定がうまくされていなかったため、 takatori を使う側でも Boost::stacktrace_backtrace への依存を明示的に記述しないとビルドが通らなくなっていました。

上記の問題は project-tsurugi/takatori#40 で修正したので、現在記述されている Boost::stacktrace_backtrace への依存を除去します。
(takatori が Boost::stacktrace_backtrace に依存しなくなったときに邪魔になります)
