### PR TITLE
fix: fix type conversion rules to fit to the spec.

### DIFF
--- a/src/yugawara/type/conversion.cpp
+++ b/src/yugawara/type/conversion.cpp
@@ -775,22 +775,29 @@ ternary is_assignment_convertible(model::data const& type, model::data const& ta
         case npair(kind::decimal, kind::decimal):
         case npair(kind::decimal, kind::float4):
         case npair(kind::decimal, kind::float8):
+            return ternary::yes;
 
         case npair(kind::float4, kind::int1):
         case npair(kind::float4, kind::int2):
         case npair(kind::float4, kind::int4):
         case npair(kind::float4, kind::int8):
         case npair(kind::float4, kind::decimal):
+            return ternary::no;
+
         case npair(kind::float4, kind::float4):
         case npair(kind::float4, kind::float8):
+            return ternary::yes;
 
         case npair(kind::float8, kind::int1):
         case npair(kind::float8, kind::int2):
         case npair(kind::float8, kind::int4):
         case npair(kind::float8, kind::int8):
         case npair(kind::float8, kind::decimal):
+            return ternary::no;
+
         case npair(kind::float8, kind::float4):
         case npair(kind::float8, kind::float8):
+            return ternary::yes;
 
         case npair(kind::character, kind::character):
 
@@ -800,20 +807,27 @@ ternary is_assignment_convertible(model::data const& type, model::data const& ta
 
         case npair(kind::date, kind::date):
         case npair(kind::date, kind::time_point):
+            return ternary::yes;
 
         case npair(kind::time_of_day, kind::time_of_day):
         case npair(kind::time_of_day, kind::time_point):
+            if (get_time_zone(type) == get_time_zone(target)) {
+                return ternary::yes;
+            }
+            return ternary::no;
 
         case npair(kind::time_point, kind::date):
+            return ternary::yes;
+
         case npair(kind::time_point, kind::time_of_day):
         case npair(kind::time_point, kind::time_point):
+            if (get_time_zone(type) == get_time_zone(target)) {
+                return ternary::yes;
+            }
+            return ternary::no;
 
         case npair(kind::datetime_interval, kind::datetime_interval):
-            return ternary::yes;
-
         case npair(kind::blob, kind::blob):
-            return ternary::yes;
-
         case npair(kind::clob, kind::clob):
             return ternary::yes;
 
@@ -850,6 +864,24 @@ ternary is_cast_convertible(takatori::type::data const& type, takatori::type::da
     }
 
     switch (npair(type.kind(), target.kind())) {
+        // allow approx. -> exact numbers
+        case npair(kind::float4, kind::int1):
+        case npair(kind::float4, kind::int2):
+        case npair(kind::float4, kind::int4):
+        case npair(kind::float4, kind::int8):
+        case npair(kind::float4, kind::decimal):
+        case npair(kind::float8, kind::int1):
+        case npair(kind::float8, kind::int2):
+        case npair(kind::float8, kind::int4):
+        case npair(kind::float8, kind::int8):
+        case npair(kind::float8, kind::decimal):
+
+        // allow time_of_day <-> time_point with any time zone
+        case npair(kind::time_of_day, kind::time_of_day):
+        case npair(kind::time_of_day, kind::time_point):
+        case npair(kind::time_point, kind::time_of_day):
+        case npair(kind::time_point, kind::time_point):
+
         // allow octet <-> blob
         case npair(kind::octet, kind::blob):
         case npair(kind::blob, kind::octet):

--- a/test/yugawara/type/type_conversion_assignment_test.cpp
+++ b/test/yugawara/type/type_conversion_assignment_test.cpp
@@ -169,12 +169,11 @@ TEST_F(type_conversion_assignment_test, float4) {
     tt::float4 left {};
 
     EXPECT_EQ(is_assignment_convertible(left, tt::boolean {}), no);
-    // NOTE: tsurugi totally denies approx to exact conversion, but compiler allows it for later compatibility.
-    EXPECT_EQ(is_assignment_convertible(left, tt::int1 {}), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::int2 {}), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::int4 {}), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::int8 {}), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::decimal {}), yes);
+    EXPECT_EQ(is_assignment_convertible(left, tt::int1 {}), no);
+    EXPECT_EQ(is_assignment_convertible(left, tt::int2 {}), no);
+    EXPECT_EQ(is_assignment_convertible(left, tt::int4 {}), no);
+    EXPECT_EQ(is_assignment_convertible(left, tt::int8 {}), no);
+    EXPECT_EQ(is_assignment_convertible(left, tt::decimal {}), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::float4 {}), yes);
     EXPECT_EQ(is_assignment_convertible(left, tt::float8 {}), yes);
     EXPECT_EQ(is_assignment_convertible(left, tt::character { ~tt::varying }), no);
@@ -194,12 +193,11 @@ TEST_F(type_conversion_assignment_test, float8) {
     tt::float8 left {};
 
     EXPECT_EQ(is_assignment_convertible(left, tt::boolean {}), no);
-    // NOTE: tsurugi totally denies approx to exact conversion, but compiler allows it for later compatibility.
-    EXPECT_EQ(is_assignment_convertible(left, tt::int1 {}), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::int2 {}), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::int4 {}), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::int8 {}), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::decimal {}), yes);
+    EXPECT_EQ(is_assignment_convertible(left, tt::int1 {}), no);
+    EXPECT_EQ(is_assignment_convertible(left, tt::int2 {}), no);
+    EXPECT_EQ(is_assignment_convertible(left, tt::int4 {}), no);
+    EXPECT_EQ(is_assignment_convertible(left, tt::int8 {}), no);
+    EXPECT_EQ(is_assignment_convertible(left, tt::decimal {}), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::float4 {}), yes);
     EXPECT_EQ(is_assignment_convertible(left, tt::float8 {}), yes);
     EXPECT_EQ(is_assignment_convertible(left, tt::character { ~tt::varying }), no);
@@ -352,9 +350,9 @@ TEST_F(type_conversion_assignment_test, time_of_day) {
     EXPECT_EQ(is_assignment_convertible(left, tt::octet { tt::varying }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::date {}), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { ~tt::with_time_zone }), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { tt::with_time_zone}), yes);
+    EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { tt::with_time_zone}), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::time_point { ~tt::with_time_zone }), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::time_point { tt::with_time_zone }), yes);
+    EXPECT_EQ(is_assignment_convertible(left, tt::time_point { tt::with_time_zone }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::blob {}), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::clob {}), no);
 }
@@ -375,9 +373,9 @@ TEST_F(type_conversion_assignment_test, time_of_day_with_time_zone) {
     EXPECT_EQ(is_assignment_convertible(left, tt::octet { ~tt::varying }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::octet { tt::varying }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::date {}), no);
-    EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { ~tt::with_time_zone }), yes);
+    EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { ~tt::with_time_zone }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { tt::with_time_zone}), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::time_point { ~tt::with_time_zone }), yes);
+    EXPECT_EQ(is_assignment_convertible(left, tt::time_point { ~tt::with_time_zone }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::time_point { tt::with_time_zone }), yes);
     EXPECT_EQ(is_assignment_convertible(left, tt::blob {}), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::clob {}), no);
@@ -400,9 +398,9 @@ TEST_F(type_conversion_assignment_test, time_point) {
     EXPECT_EQ(is_assignment_convertible(left, tt::octet { tt::varying }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::date {}), yes);
     EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { ~tt::with_time_zone }), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { tt::with_time_zone}), yes);
+    EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { tt::with_time_zone}), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::time_point { ~tt::with_time_zone }), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::time_point { tt::with_time_zone }), yes);
+    EXPECT_EQ(is_assignment_convertible(left, tt::time_point { tt::with_time_zone }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::blob {}), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::clob {}), no);
 }
@@ -423,9 +421,9 @@ TEST_F(type_conversion_assignment_test, time_point_with_time_zone) {
     EXPECT_EQ(is_assignment_convertible(left, tt::octet { ~tt::varying }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::octet { tt::varying }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::date {}), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { ~tt::with_time_zone }), yes);
+    EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { ~tt::with_time_zone }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::time_of_day { tt::with_time_zone}), yes);
-    EXPECT_EQ(is_assignment_convertible(left, tt::time_point { ~tt::with_time_zone }), yes);
+    EXPECT_EQ(is_assignment_convertible(left, tt::time_point { ~tt::with_time_zone }), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::time_point { tt::with_time_zone }), yes);
     EXPECT_EQ(is_assignment_convertible(left, tt::blob {}), no);
     EXPECT_EQ(is_assignment_convertible(left, tt::clob {}), no);


### PR DESCRIPTION
This PR fixes type conversion rules in SQL compiler, to fit the specification.

This includes the following changes:

* In assignment conversion, Approx. numbers must not convert into exact numbers
* Goes along https://github.com/project-tsurugi/takatori/pull/42
