### PR TITLE
fix: accept equality comparison of `NULL`.

### DIFF
--- a/src/yugawara/type/comparable.cpp
+++ b/src/yugawara/type/comparable.cpp
@@ -46,11 +46,11 @@ bool is_equality_comparable(::takatori::type::data const& type) noexcept {
         case k::datetime_interval:
         case k::array:
         case k::record:
+        case k::unknown:
             return true;
 
         case k::blob:
         case k::clob:
-        case k::unknown:
         case k::row_id:
         case k::declared:
         default:

--- a/test/yugawara/type/type_comparable_test.cpp
+++ b/test/yugawara/type/type_comparable_test.cpp
@@ -45,7 +45,7 @@ TEST_F(type_comparable_test, is_equality_comparable) {
     EXPECT_TRUE(is_equality_comparable(tt::datetime_interval()));
     EXPECT_FALSE(is_equality_comparable(tt::blob {}));
     EXPECT_FALSE(is_equality_comparable(tt::clob {}));
-    EXPECT_FALSE(is_equality_comparable(tt::unknown()));
+    EXPECT_TRUE(is_equality_comparable(tt::unknown()));
     EXPECT_FALSE(is_equality_comparable(extension::type::error()));
     EXPECT_FALSE(is_equality_comparable(extension::type::pending()));
 }


### PR DESCRIPTION
This PR will accept equality comparison of unknown type values (`NULL = NULL`).
It has denied in https://github.com/project-tsurugi/yugawara/commit/460f3a5c81e886b01bc0922cab6f377a74cf39c4, and it was defined in https://github.com/project-tsurugi/yugawara/commit/da352b6b33fb2aa0608d3740a62584fea80ce1ca.