### PR TITLE
ci: change Analysis job env to almalinux/clang

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks: "-*,\
 abseil-*,\
 boost-*,\
+-boost-use-ranges,\
 bugprone-*,\
 -bugprone-branch-clone,\
 -bugprone-easily-swappable-parameters,\
@@ -49,6 +50,7 @@ readability-*,\
 -readability-braces-around-statements,\
 -readability-identifier-length,\
 -readability-convert-member-functions-to-static,\
+-readability-math-missing-parentheses,\
 -readability-named-parameter,\
 -readability-magic-numbers,\
 -readability-qualified-auto,\

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -65,7 +65,7 @@ jobs:
       checks: write
     timeout-minutes: 30
     container:
-      image: ghcr.io/project-tsurugi/tsurugi-ci:ubuntu-22.04
+      image: ghcr.io/project-tsurugi/tsurugi-ci:almalinux-latest
       volumes:
         - ${{ vars.ccache_dir }}:${{ vars.ccache_dir }}
     defaults:
@@ -73,7 +73,9 @@ jobs:
         shell: bash
     env:
       CCACHE_CONFIGPATH: ${{ vars.ccache_dir }}/ccache.conf
-      CCACHE_DIR: ${{ vars.ccache_dir }}/ubuntu-22.04
+      CCACHE_DIR: ${{ vars.ccache_dir }}/almalinux-latest
+      CC: clang
+      CXX: clang++
 
     steps:
       - name: Checkout
@@ -86,15 +88,16 @@ jobs:
         with:
           cmake_build_option: ${{ inputs.cmake_build_option }}
 
-      - name: CMake_Generate
+      - name: CMake_Build
         run: |
           mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_STRICT=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
+          cmake --build . --target all --clean-first
 
       - name: Clang-Tidy
         run: |
-          python tools/bin/run-clang-tidy.py -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(include|src)/.*\.h$' $(pwd)'/src/.*' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
+          python3 tools/bin/run-clang-tidy.py -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(include|src)/.*\.h$' $(pwd)'/src/.*' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
 
       - name: Doxygen
         run: |

--- a/src/yugawara/analyzer/block_algorithm.cpp
+++ b/src/yugawara/analyzer/block_algorithm.cpp
@@ -3,7 +3,7 @@
 namespace yugawara::analyzer {
 
 template<class G, class C>
-void collect_heads0(G& g, C const& consumer) {
+static void collect_heads0(G& g, C const& consumer) {
     for (auto&& b : g) {
         if (b.upstreams().empty()) {
             consumer(b);
@@ -20,7 +20,7 @@ void collect_heads(block_graph const& g, const_block_consumer const& consumer) {
 }
 
 template<class G, class C>
-void collect_tails0(G& g, C const& consumer) {
+static void collect_tails0(G& g, C const& consumer) {
     for (auto&& b : g) {
         if (b.downstreams().empty()) {
             consumer(b);
@@ -37,7 +37,7 @@ void collect_tails(block_graph const& g, const_block_consumer const& consumer) {
 }
 
 template<class B, class G>
-::takatori::util::optional_ptr<B> find_unique_head0(G& g) noexcept {
+static ::takatori::util::optional_ptr<B> find_unique_head0(G& g) noexcept {
     B* result {};
     for (auto&& b : g) {
         if (b.upstreams().empty()) {
@@ -60,7 +60,7 @@ template<class B, class G>
 }
 
 template<class B>
-::takatori::util::optional_ptr<B> find_unique_upstream0(B& b) noexcept {
+static ::takatori::util::optional_ptr<B> find_unique_upstream0(B& b) noexcept {
     auto candidates = b.upstreams();
     if (candidates.size() == 1) {
         return candidates[0];
@@ -77,7 +77,7 @@ template<class B>
 }
 
 template<class B>
-::takatori::util::optional_ptr<B> find_unique_downstream0(B& b) noexcept {
+static ::takatori::util::optional_ptr<B> find_unique_downstream0(B& b) noexcept {
     auto candidates = b.downstreams();
     if (candidates.size() == 1) {
         return candidates[0];

--- a/src/yugawara/analyzer/details/container_pool.h
+++ b/src/yugawara/analyzer/details/container_pool.h
@@ -31,8 +31,16 @@ public:
      * @brief creates a new instance.
      * @param allocator the container's allocator
      */
-    explicit container_pool(allocator_type allocator = {}) noexcept
-        : entries_(typename decltype(entries_)::allocator_type { std::move(allocator) })
+    explicit container_pool(allocator_type const& allocator) noexcept:
+            entries_(typename decltype(entries_)::allocator_type { allocator })
+    {}
+
+    /**
+     * @brief creates a new instance.
+     * @param allocator the container's allocator
+     */
+    explicit container_pool(allocator_type&& allocator = {}) noexcept:
+            entries_(typename decltype(entries_)::allocator_type { std::move(allocator) })
     {}
 
     /**

--- a/src/yugawara/analyzer/details/remove_redundant_stream_variables.cpp
+++ b/src/yugawara/analyzer/details/remove_redundant_stream_variables.cpp
@@ -154,10 +154,10 @@ public:
     void operator()(relation::intermediate::union_& expr) {
         remove_unused_mappings(expr.mappings());
         for (auto&& mapping : expr.mappings()) {
-            if (auto v = mapping.left()) {
+            if (auto&& v = mapping.left()) {
                 use(*v);
             }
-            if (auto v = mapping.right()) {
+            if (auto&& v = mapping.right()) {
                 use(*v);
             }
         }

--- a/src/yugawara/binding/extract.cpp
+++ b/src/yugawara/binding/extract.cpp
@@ -35,7 +35,7 @@ relation_info_kind kind_of(descriptor::relation const& descriptor) {
 }
 
 template<class Info, class Desc>
-optional_ptr<Info const> unwrap_as(Desc const& desc, bool fail_if_mismatch) {
+static optional_ptr<Info const> unwrap_as(Desc const& desc, bool fail_if_mismatch) {
     using info_type = Info;
     auto&& info = unwrap(desc);
     if (info.kind() == info_type::tag) {

--- a/src/yugawara/type/category.cpp
+++ b/src/yugawara/type/category.cpp
@@ -12,7 +12,13 @@
 
 namespace yugawara::type {
 
-inline category extension_category_of(takatori::type::extension const& type) noexcept;
+static category extension_category_of(takatori::type::extension const& type) noexcept {
+    if (extension::type::error::is_instance(type)
+            || extension::type::pending::is_instance(type)) {
+        return category::unresolved;
+            }
+    return category::external;
+}
 
 category category_of(takatori::type::data const& type) noexcept {
     using kind = takatori::type::type_kind;
@@ -73,14 +79,6 @@ category category_of(takatori::type::data const& type) noexcept {
             return extension_category_of(takatori::util::unsafe_downcast<takatori::type::extension>(type));
     }
     std::abort();
-}
-
-inline category extension_category_of(takatori::type::extension const& type) noexcept {
-    if (extension::type::error::is_instance(type)
-            || extension::type::pending::is_instance(type)) {
-        return category::unresolved;
-    }
-    return category::external;
 }
 
 } // namespace yugawara::type

--- a/src/yugawara/type/conversion.cpp
+++ b/src/yugawara/type/conversion.cpp
@@ -143,7 +143,7 @@ std::shared_ptr<model::data const> identity_conversion(model::data const& type, 
     return repo.get(type);
 }
 
-std::shared_ptr<model::data const> identity_conversion(
+static std::shared_ptr<model::data const> identity_conversion(
         model::data const& type,
         model::data const& with,
         repository& repo) {


### PR DESCRIPTION
CI environment changes to enable build compatibility verification with Clang on AlmaLinux and static analysis with new version of Clang-Tidy on Analysis job.