### PR TITLE
ci: bump actions for deprecation of Node 20

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -17,7 +17,7 @@ runs:
 
   steps:
     - name: Checkout_Takatori
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.checkout == 'true' }}
       with:
         repository: project-tsurugi/takatori

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -60,7 +60,7 @@ jobs:
           ctest --verbose -j 16
 
       - name: Verify
-        uses: project-tsurugi/tsurugi-annotations-action@v1
+        uses: project-tsurugi/tsurugi-annotations-action@v2
         if: always()
 
   Analysis:
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -116,5 +116,5 @@ jobs:
           ninja doxygen 2> >(tee doxygen-error.log)
 
       - name: Verify
-        uses: project-tsurugi/tsurugi-annotations-action@v1
+        uses: project-tsurugi/tsurugi-annotations-action@v2
         if: always()


### PR DESCRIPTION
This pull request updates CI workflow dependencies to the latest versions of key GitHub Actions in preparation for the upcoming removal of Node 20 from GitHub Actions runners.
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/